### PR TITLE
Linux build: force delete of Dependencies

### DIFF
--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -579,7 +579,7 @@
   </Target>
 
 	<Target Name="PreBuildLinux" BeforeTargets="PreBuildEvent" Condition="'$(RuntimeIdentifier)'=='linux-x64'">
-    <Exec Command="cd $(OutDir)&#xD;&#xA;rm -r Dependencies&#xD;&#xA;mkdir Dependencies&#xD;&#xA;cp -R $(ProjectDir)/Dependencies/* Dependencies&#xD;&#xA;cp libHarfBuzzSharp.so Dependencies&#xD;&#xA;cp libSkiaSharp.so Dependencies&#xD;&#xA;cp MesenCore.so Dependencies&#xD;&#xA;cd Dependencies&#xD;&#xA;rm ../Dependencies.zip&#xD;&#xA;zip -r ../Dependencies.zip *&#xD;&#xA;cp ../Dependencies.zip $(ProjectDir)" />
+    <Exec Command="cd $(OutDir)&#xD;&#xA;rm -rf Dependencies&#xD;&#xA;mkdir Dependencies&#xD;&#xA;cp -R $(ProjectDir)/Dependencies/* Dependencies&#xD;&#xA;cp libHarfBuzzSharp.so Dependencies&#xD;&#xA;cp libSkiaSharp.so Dependencies&#xD;&#xA;cp MesenCore.so Dependencies&#xD;&#xA;cd Dependencies&#xD;&#xA;rm ../Dependencies.zip&#xD;&#xA;zip -r ../Dependencies.zip *&#xD;&#xA;cp ../Dependencies.zip $(ProjectDir)" />
   </Target>
   
 	<Target Name="PreBuildOsx" BeforeTargets="PreBuildEvent" Condition="'$(RuntimeIdentifier)'=='osx-x64' Or '$(RuntimeIdentifier)'=='osx-arm64'">


### PR DESCRIPTION
When attempting to build on Ubuntu 22, the publish step was hanging here indefinitely:

```
  $ make
  mkdir -p bin/linux-x64/Release/Dependencies
  rm -fr bin/linux-x64/Release/Dependencies/*
  cp InteropDLL/obj.linux-x64/MesenCore.so bin/linux-x64/Release/MesenCore.so
  #Called twice because the first call copies native libraries to the bin folder which need to be included in Dependencies.zip
  cd UI && dotnet publish -c Release -p:OptimizeUi="true" -r linux-x64 --no-self-contained true -p:PublishSingleFile=true
  Microsoft (R) Build Engine version 17.0.1+b177f8fa7 for .NET
  Copyright (C) Microsoft Corporation. All rights reserved.
  
    Determining projects to restore...
    All projects are up-to-date for restore.
```


Enabling verbose output showed that when trying to perform the command `rm -r Dependencies`, the os was looking for confirmation:

```
rm: remove write-protected directory 'Dependencies'? 
```

The build succeeded after forcing the delete.